### PR TITLE
Changed wavesurfer to use HTML5 Media backend for better compatibility

### DIFF
--- a/javascript/script.js
+++ b/javascript/script.js
@@ -95,6 +95,7 @@ window.initWaveSurfer = (src) => {
     } else {
         window.wavesurfer = WaveSurfer.create({
             container: '#wavesurferContainer',
+            backend: 'MediaElement',
             waveColor: `#${window.currentGame.themeColourPrimary}`,
             height: 100,
             progressColor: 'white',


### PR DESCRIPTION
Forced wavesurfer backend of HTML5 Media instead of the default of Web Audio to solve some instances IO buffering issues. Since the additional features offered by Web Audio are not used (filtering and channel control) this should not impact functionality.