### PR TITLE
Change editor selection behavior to more closely resemble windows behavior

### DIFF
--- a/javascript/editor.js
+++ b/javascript/editor.js
@@ -154,8 +154,9 @@ class Editor {
             if (isOnEGrabber) {
 
                 const eGrabber = isOnEGrabber
-
-                this.setLetterFocus(this.energyGrabbers.indexOf(eGrabber), event.ctrlKey, event.shiftKey, event.altKey)
+                if (this.letterFocus.length <= 1 || (!this.letterFocus.includes(eGrabber.index))) {
+                    this.setLetterFocus(this.energyGrabbers.indexOf(eGrabber), event.ctrlKey, event.shiftKey, event.altKey)
+                }
                 this.multiLetterEnergyDelta = eGrabber.topLeftY
                 this.multiLetterStartEnergyVals = this.energyGrabbers.map(eGrabber => eGrabber.topLeftY)
 
@@ -170,8 +171,9 @@ class Editor {
             if (isOnGrabber) {
 
                 const slider = isOnGrabber
-
-                this.setLetterFocus(this.grabbers.indexOf(slider), event.ctrlKey, event.shiftKey, event.altKey)
+                if (this.letterFocus.length <= 1 || (!this.letterFocus.includes(slider.index))) {
+                    this.setLetterFocus(this.grabbers.indexOf(slider), event.ctrlKey, event.shiftKey, event.altKey)
+                }
                 this.multiLetterPitchDelta = slider.topLeftY
                 this.multiLetterStartPitchVals = this.grabbers.map(slider => slider.topLeftY)
 
@@ -385,7 +387,7 @@ class Editor {
         // Ctrl + Shift = (See Shift)
         // Alt = Clear selection and select word surrounding l (space delimited)
         // Ctrl + Alt = Add word surrounding l to existing selection
-        // Shift + Alt = Same as shift, then select word (space delimited) around l
+        // Shift + Alt = Same as shift, then afterwards add word (space delimited) around l to selection
         // Ctrl + Shift + Alt = (See Shift + Alt)
 
         // If nothing is selected and we hold shift, we assume we start from the first letter: at position 0

--- a/javascript/editor.js
+++ b/javascript/editor.js
@@ -24,6 +24,7 @@ class Editor {
         this.inputSequence = undefined
         this.currentVoice = undefined
         this.letterFocus = []
+        this.lastSelected = 0
         this.letterClasses = []
         this.resetDurs = []
         this.resetPitch = []
@@ -154,9 +155,7 @@ class Editor {
 
                 const eGrabber = isOnEGrabber
 
-                if (this.letterFocus.length <= 1 || (!event.ctrlKey && !this.letterFocus.includes(eGrabber.index))) {
-                    this.setLetterFocus(this.energyGrabbers.indexOf(eGrabber), event.ctrlKey, event.shiftKey, event.altKey)
-                }
+                this.setLetterFocus(this.energyGrabbers.indexOf(eGrabber), event.ctrlKey, event.shiftKey, event.altKey)
                 this.multiLetterEnergyDelta = eGrabber.topLeftY
                 this.multiLetterStartEnergyVals = this.energyGrabbers.map(eGrabber => eGrabber.topLeftY)
 
@@ -172,9 +171,7 @@ class Editor {
 
                 const slider = isOnGrabber
 
-                if (this.letterFocus.length <= 1 || (!event.ctrlKey && !this.letterFocus.includes(slider.index))) {
-                    this.setLetterFocus(this.grabbers.indexOf(slider), event.ctrlKey, event.shiftKey, event.altKey)
-                }
+                this.setLetterFocus(this.grabbers.indexOf(slider), event.ctrlKey, event.shiftKey, event.altKey)
                 this.multiLetterPitchDelta = slider.topLeftY
                 this.multiLetterStartPitchVals = this.grabbers.map(slider => slider.topLeftY)
 
@@ -381,20 +378,51 @@ class Editor {
     }
 
     setLetterFocus (l, ctrlKey, shiftKey, altKey) {
-        // On alt key modifier, make a selection on the whole whole word
-        if (altKey) {
-            this.letterFocus.push(l)
-            let l2 = l
-            // Looking backwards
-            while (l2>=0) {
-                let prevLetter = this.letters[l2]
-                if (prevLetter!="_") {
-                    this.letterFocus.push(l2)
-                } else {
-                    break
+        
+        // NONE = Clear selection, add l to selection
+        // Ctrl = Add l to existing selection
+        // Shift = Add all letters from the last selected letter up to and including l to existing selection
+        // Ctrl + Shift = (See Shift)
+        // Alt = Clear selection and select word surrounding l (space delimited)
+        // Ctrl + Alt = Add word surrounding l to existing selection
+        // Shift + Alt = Add all words (including spaces) from last selected letter to l, then select word (space delimited) around l
+        // Ctrl + Shift + Alt = (See Shift + Alt)
+
+        // If nothing is selected and we hold shift, we assume we start from the first letter: at position 0
+        
+        // If we don't press shift or ctrl, we can clear our current selection.
+        if (!(ctrlKey || shiftKey) && this.letterFocus.length){
+                this.letterFocus.forEach(li => {
+                    this.letterClasses[li].colour = "black"
+                })
+                this.letterFocus = []
+                this.lastSelected = 0
+        }
+        if (shiftKey){
+            if (l>this.lastSelected) {
+                for (let i=this.lastSelected; i<=l; i++) {
+                    this.letterFocus.push(i)
                 }
-                l2--
+            } else {
+                for (let i=l; i<=this.lastSelected; i++) {
+                    this.letterFocus.push(i)
+                }
             }
+        }
+        this.letterFocus.push(l) // Push l
+        this.lastSelected = l
+        if (altKey){
+            let l2 = l
+                // Looking backwards
+                while (l2>=0) {
+                    let prevLetter = this.letters[l2]
+                    if (prevLetter!="_") {
+                        this.letterFocus.push(l2)
+                    } else {
+                        break
+                    }
+                    l2--
+                }
             l2 = l
             // Looking forward
             while (l2<this.letters.length) {
@@ -405,32 +433,6 @@ class Editor {
                     break
                 }
                 l2++
-            }
-
-        } else {
-
-            if (shiftKey && this.letterFocus.length) {
-                const lastSelected = this.letterFocus[this.letterFocus.length-1]
-
-                if (l>lastSelected) {
-                    for (let i=lastSelected; i<=l; i++) {
-                        this.letterFocus.push(i)
-                    }
-                } else {
-                    for (let i=l; i<=this.letterFocus[0]; i++) {
-                        this.letterFocus.push(i)
-                    }
-                }
-            } else {
-                if (this.letterFocus.length && !ctrlKey) {
-                    this.letterFocus.forEach(li => {
-                        this.letterClasses[li].colour = "black"
-                    })
-
-
-                    this.letterFocus = []
-                }
-                this.letterFocus.push(l)
             }
         }
 

--- a/javascript/editor.js
+++ b/javascript/editor.js
@@ -385,7 +385,7 @@ class Editor {
         // Ctrl + Shift = (See Shift)
         // Alt = Clear selection and select word surrounding l (space delimited)
         // Ctrl + Alt = Add word surrounding l to existing selection
-        // Shift + Alt = Add all words (including spaces) from last selected letter to l, then select word (space delimited) around l
+        // Shift + Alt = Same as shift, then select word (space delimited) around l
         // Ctrl + Shift + Alt = (See Shift + Alt)
 
         // If nothing is selected and we hold shift, we assume we start from the first letter: at position 0


### PR DESCRIPTION
Hi, I decided to have a go at changing the editor's selection behavior to more closely resemble windows explorer and other programs. It was discussed a while ago in the discord suggestions'. (I'm Mobius#4304)
[message here](https://discord.com/channels/794590496202293278/794598305191297025/1002630990159696002) 

New behavior (with `l` being the selected letter):

- no modifiers = Clear selection, add `l` to selection
- Ctrl = Add `l` to existing selection
- Shift = Add all letters from the last selected letter up to and including `l` to existing selection
- Ctrl + Shift = (See Shift)
- Alt = Clear selection and select word surrounding `l` (space delimited)
- Ctrl + Alt = Add word surrounding `l` to existing selection
- Shift + Alt = Same behavior as Shift, then afterwards select word (space delimited) around `l`
- Ctrl + Shift + Alt = (See Shift + Alt)

I did also change the fact that Ctrl blocks adding a letter to your selection if you're dragging an unselected letter around, for consistency's sake.

This is my first open source pull request ever, so let me know if I dun goofed somewhere. 😁 